### PR TITLE
Repa and datatype stuff

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,12 +6,12 @@ import Point
 import Raytrace(raytrace)
 import Vector
 
-test_scene = ([ Sphere (Point (0, 0, 500)) 100 (RGB (50, 70, 90)),
-                Sphere (Point (100, 80, 450)) 50 (RGB (250, 30, 10)),
-                Sphere (Point (-100, -50, 600)) 120 (RGB (200, 220, 250)) ],
-              [ (Point (-200, -200, 500), (RGB(200, 10, 10))),
-                (Point (80, -100, 300), (RGB(0, 40, 200))),
-                (Point (150, -20, 400), (RGB(60, 120, 60))) ])
+test_scene = ([ Sphere (Point (Vector 0 0 500)) 100 (RGB 50 70 90),
+                Sphere (Point (Vector 100 80 450)) 50 (RGB 250 30 10),
+                Sphere (Point (Vector (-100) (-50) 600)) 120 (RGB 200 220 250)],
+              [ (Point (Vector (-200) (-200) 500), (RGB 200 10 10)),
+                (Point (Vector 80 (-100) 300), (RGB 0 40 200)),
+                (Point (Vector 150 (-20) 400), (RGB 60 120 60)) ])
 
 main :: IO ()
 main = writeFile "test.ppm" test

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,19 +1,17 @@
-module Main where
+module Main(main) where
 
 import Intersect
 import Image
 import Point
-import Raytrace(raytrace)
+import Raytrace(raytrace, Light(..))
 import Vector
 
 test_scene = ([ Sphere (Point (Vector 0 0 500)) 100 (RGB 50 70 90),
                 Sphere (Point (Vector 100 80 450)) 50 (RGB 250 30 10),
                 Sphere (Point (Vector (-100) (-50) 600)) 120 (RGB 200 220 250)],
-              [ (Point (Vector (-200) (-200) 500), (RGB 200 10 10)),
-                (Point (Vector 80 (-100) 300), (RGB 0 40 200)),
-                (Point (Vector 150 (-20) 400), (RGB 60 120 60)) ])
+              [ Light (Point (Vector (-200) (-200) 500)) (RGB 200 10 10),
+                Light (Point (Vector 80 (-100) 300)) (RGB 0 40 200),
+                Light (Point (Vector 150 (-20) 400)) (RGB 60 120 60) ])
 
 main :: IO ()
-main = writeFile "test.ppm" test
-  where
-    test = create_ppm $ raytrace test_scene 1024 1024
+main = write_ppm "test.ppm" (raytrace test_scene 1024 1024)

--- a/htracer.cabal
+++ b/htracer.cabal
@@ -20,7 +20,10 @@ library
                      , Point
                      , Raytrace
                      , Vector
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base
+                     , deepseq
+                     , lens
+                     , parallel
                      , tuple
   default-language:    Haskell2010
 

--- a/htracer.cabal
+++ b/htracer.cabal
@@ -22,12 +22,14 @@ library
                      , Vector
   build-depends:       base
                      , bytestring >= 0.10.6.0
+                     , repa
+                     , vector
   default-language:    Haskell2010
 
 executable htracer-exe
   hs-source-dirs:      app
   main-is:             Main.hs
-  ghc-options:         -rtsopts -funbox-strict-fields
+  ghc-options:         -rtsopts -funbox-strict-fields -threaded
   build-depends:       base
                      , htracer
   default-language:    Haskell2010

--- a/htracer.cabal
+++ b/htracer.cabal
@@ -21,16 +21,13 @@ library
                      , Raytrace
                      , Vector
   build-depends:       base
-                     , deepseq
-                     , lens
-                     , parallel
-                     , tuple
+                     , bytestring >= 0.10.6.0
   default-language:    Haskell2010
 
 executable htracer-exe
   hs-source-dirs:      app
   main-is:             Main.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -rtsopts -funbox-strict-fields
   build-depends:       base
                      , htracer
   default-language:    Haskell2010
@@ -41,7 +38,7 @@ test-suite htracer-test
   main-is:             Spec.hs
   build-depends:       base
                      , htracer
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -rtsopts
   default-language:    Haskell2010
 
 source-repository head

--- a/src/Image.hs
+++ b/src/Image.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BangPatterns #-}
 module Image (RGB(..), Image(..), write_ppm) where
 
 import Data.List
 import Data.Monoid
+import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.ByteString.Builder as BLB
+import qualified Data.Vector.Unboxed as V
+
+import System.IO
 
 data RGB = RGB {r :: !Int,
                 g :: !Int,
@@ -23,32 +28,47 @@ intByteString = BLB.toLazyByteString . BLB.intDec
 rgb_to_str :: RGB -> BLB.Builder
 rgb_to_str (RGB r g b) = BLB.intDec r <> " " <> BLB.intDec g <> " " <> BLB.intDec b
 
+rgb_tuple_to_str :: (Int, Int, Int) -> BLB.Builder
+rgb_tuple_to_str (!r, !g, !b) = BLB.intDec r <> " " <> BLB.intDec g <> " " <> BLB.intDec b
+
+
 -- Test for rgb_to_str
 test_rgb_to_str :: Bool
 test_rgb_to_str = BLB.toLazyByteString (rgb_to_str (RGB 11 12 13)) == "11 12 13"
 
-newtype Image = Image (Int, Int, [RGB])
+newtype Image = Image (Int, Int, V.Vector (Int, Int, Int))
 
 -- Create a ppm file.
 create_ppm :: Image -> BL.ByteString
 create_ppm (Image (w, h, ps)) = BL.unlines line_list
   where
-    rgbs = BLB.toLazyByteString
-      (mconcat (intersperse (BLB.char8 '\n') (map rgb_to_str ps)))
+    rgbs = BLB.toLazyByteString (V.foldl' go "" ps)
+    go acc (r, g, b) = acc <> (rgb_to_str (RGB r g b)) <> "\n"
 
     line_list :: [BL.ByteString]
     line_list = ["P3", BL.unwords [intByteString w, intByteString h], "255", rgbs]
 
 write_ppm :: FilePath -> Image -> IO ()
-write_ppm file = BL.writeFile file . create_ppm
+write_ppm file (Image (w, h, ps)) = withFile  file WriteMode $ \ hdl -> do
+  hSetBuffering hdl (BlockBuffering Nothing)
+  B.hPutStrLn hdl "P3"
+  BL.hPutStrLn hdl (BL.unwords [intByteString w, intByteString h])
+  -- V.mapM_ (\ rgb -> do
+  --             BLB.hPutBuilder hdl (rgb_tuple_to_str rgb)
+  --             B.putStrLn "\n"
+  --         ) ps
+  let bld = V.foldr (\ rgb acc -> acc <> rgb_tuple_to_str rgb <> "\n") "" ps
+  BLB.hPutBuilder hdl bld
+
+rgbsToTuples = V.fromList . map (\ (RGB r g b) -> (r, g, b))
 
 -- -- Test for create_ppm
 test_create_ppm :: Bool
-test_create_ppm = create_ppm (Image (2, 3, [RGB 11 12 13, RGB 22 23 24,
-                                            RGB 33 34 35, RGB 44 45 46,
-                                            RGB 55 56 57, RGB 66 67 68])) ==
+test_create_ppm = create_ppm (Image (2, 3, rgbsToTuples [RGB 11 12 13, RGB 22 23 24,
+                                                         RGB 33 34 35, RGB 44 45 46,
+                                                         RGB 55 56 57, RGB 66 67 68])) ==
                   "P3\n2 3\n255\n11 12 13\n22 23 24\n33 34 35\n44 45 46\n55 56 57\n66 67 68\n"
 
-test_write_ppm = write_ppm "test.ppm" (Image (16, 16, (map mkrgb [0..255])))
-  where
-    mkrgb x = RGB x x x
+-- test_write_ppm = write_ppm "test.ppm" (Image (16, 16, (map mkrgb [0..255])))
+--   where
+--     mkrgb x = RGB x x x

--- a/src/Image.hs
+++ b/src/Image.hs
@@ -49,12 +49,7 @@ create_ppm (Image (w, h, ps)) =
 write_ppm :: FilePath -> Image -> IO ()
 write_ppm file img@(Image (w, h, ps)) = withFile  file WriteMode $ \ hdl -> do
   hSetBuffering hdl (BlockBuffering Nothing)
-  -- BLB.hPutBuilder hdl (create_ppm img)
-  B.hPutStrLn hdl "P3"
-  BL.hPutStrLn hdl (BL.unwords [intByteString w, intByteString h])
-  BL.hPutStrLn hdl "255"
-  let bld = V.foldr (\ rgb acc -> acc <> rgb_tuple_to_str rgb <> "\n") "" ps
-  BLB.hPutBuilder hdl bld
+  BLB.hPutBuilder hdl (create_ppm img)
 
 rgbsToTuples = V.fromList . map (\ (RGB r g b) -> (r, g, b))
 

--- a/src/Image.hs
+++ b/src/Image.hs
@@ -39,24 +39,20 @@ test_rgb_to_str = BLB.toLazyByteString (rgb_to_str (RGB 11 12 13)) == "11 12 13"
 newtype Image = Image (Int, Int, V.Vector (Int, Int, Int))
 
 -- Create a ppm file.
-create_ppm :: Image -> BL.ByteString
-create_ppm (Image (w, h, ps)) = BL.unlines line_list
-  where
-    rgbs = BLB.toLazyByteString (V.foldl' go "" ps)
-    go acc (r, g, b) = acc <> (rgb_to_str (RGB r g b)) <> "\n"
-
-    line_list :: [BL.ByteString]
-    line_list = ["P3", BL.unwords [intByteString w, intByteString h], "255", rgbs]
+create_ppm :: Image -> BLB.Builder
+create_ppm (Image (w, h, ps)) =
+  "P3\n" <>
+  "255\n" <>
+  BLB.intDec w <> " " <> BLB.intDec h <> "\n" <>
+  V.foldr (\ rgb acc -> acc <> rgb_tuple_to_str rgb <> "\n") "" ps
 
 write_ppm :: FilePath -> Image -> IO ()
-write_ppm file (Image (w, h, ps)) = withFile  file WriteMode $ \ hdl -> do
+write_ppm file img@(Image (w, h, ps)) = withFile  file WriteMode $ \ hdl -> do
   hSetBuffering hdl (BlockBuffering Nothing)
+  -- BLB.hPutBuilder hdl (create_ppm img)
   B.hPutStrLn hdl "P3"
   BL.hPutStrLn hdl (BL.unwords [intByteString w, intByteString h])
-  -- V.mapM_ (\ rgb -> do
-  --             BLB.hPutBuilder hdl (rgb_tuple_to_str rgb)
-  --             B.putStrLn "\n"
-  --         ) ps
+  BL.hPutStrLn hdl "255"
   let bld = V.foldr (\ rgb acc -> acc <> rgb_tuple_to_str rgb <> "\n") "" ps
   BLB.hPutBuilder hdl bld
 
@@ -64,9 +60,11 @@ rgbsToTuples = V.fromList . map (\ (RGB r g b) -> (r, g, b))
 
 -- -- Test for create_ppm
 test_create_ppm :: Bool
-test_create_ppm = create_ppm (Image (2, 3, rgbsToTuples [RGB 11 12 13, RGB 22 23 24,
-                                                         RGB 33 34 35, RGB 44 45 46,
-                                                         RGB 55 56 57, RGB 66 67 68])) ==
+test_create_ppm = BLB.toLazyByteString (
+  create_ppm (Image (2, 3,
+                     rgbsToTuples [RGB 11 12 13, RGB 22 23 24,
+                                   RGB 33 34 35, RGB 44 45 46,
+                                   RGB 55 56 57, RGB 66 67 68]))) ==
                   "P3\n2 3\n255\n11 12 13\n22 23 24\n33 34 35\n44 45 46\n55 56 57\n66 67 68\n"
 
 -- test_write_ppm = write_ppm "test.ppm" (Image (16, 16, (map mkrgb [0..255])))

--- a/src/Image.hs
+++ b/src/Image.hs
@@ -1,5 +1,8 @@
 module Image where
 
+import Control.DeepSeq
+import Control.Lens
+
 import Data.Tuple.Select
 
 -- Join a list of strings using a separator.
@@ -11,32 +14,28 @@ join sep (x:xs) = x ++ sep ++ join sep xs
 test_join :: Bool
 test_join = join "t" ["12", "3", "", "xy"] == "12t3ttxy"
 
-newtype RGB = RGB (Int, Int, Int)
+data RGB = RGB {r :: !Int,
+                g :: !Int,
+                b :: !Int}
+
+instance NFData RGB where
+  rnf (RGB _ _ _) = ()
+
+rgb :: Iso' RGB (Int, Int, Int)
+rgb = iso (\(RGB r g b) -> (r, g, b)) ( \ (r, g, b) -> RGB r g b)
 
 instance Show RGB where show rgb = show $ rgb_to_str rgb
 
 instance Num RGB where
-  (+) (RGB a) (RGB b) = RGB (sel1 a + sel1 b,
-                             sel2 a + sel2 b,
-                             sel3 a + sel3 b)
+  (+) (RGB r1 g1 b1) (RGB r2 g2 b2) = RGB (r1 + r2) (g1 + g2) (b1 + b2)
 
 -- Convert an RGB to a String
 rgb_to_str :: RGB -> String
-rgb_to_str (RGB (r,g,b)) = join " " $ map show [r,g,b]
-
-rgb_to_list :: RGB -> [Int]
-rgb_to_list (RGB (r,g,b)) = [r,g,b]
-
-rgb_to_integer_list :: RGB -> [Integer]
-rgb_to_integer_list r = map toInteger (rgb_to_list r)
-
-rgb_from_list :: [Integer] -> RGB
-rgb_from_list l = RGB (l'!!0, l'!!1, l'!!2)
-  where l' = map fromInteger l
+rgb_to_str (RGB r g b) = join " " $ map show [r,g,b]
 
 -- Test for rgb_to_str
 test_rgb_to_str :: Bool
-test_rgb_to_str = rgb_to_str (RGB (11,12,13)) == "11 12 13"
+test_rgb_to_str = rgb_to_str (RGB 11 12 13) == "11 12 13"
 
 newtype Image = Image (Int, Int, [RGB])
 
@@ -48,11 +47,11 @@ create_ppm (Image (w, h, ps)) = join "\n" line_list ++ "\n"
 
 -- -- Test for create_ppm
 test_create_ppm :: Bool
-test_create_ppm = create_ppm (Image (2, 3, [RGB (11,12,13), RGB (22,23,24),
-                                            RGB (33,34,35), RGB (44,45,46),
-                                            RGB (55,56,57), RGB (66,67,68)])) ==
+test_create_ppm = create_ppm (Image (2, 3, [RGB 11 12 13, RGB 22 23 24,
+                                            RGB 33 34 35, RGB 44 45 46,
+                                            RGB 55 56 57, RGB 66 67 68])) ==
                   "P3\n2 3\n255\n11 12 13\n22 23 24\n33 34 35\n44 45 46\n55 56 57\n66 67 68\n"
 
 test_write_ppm = writeFile "test.ppm" $ create_ppm (Image (16, 16, (map mkrgb [0..255])))
   where
-    mkrgb x = RGB(x,x,x)
+    mkrgb x = RGB x x x

--- a/src/Image.hs
+++ b/src/Image.hs
@@ -42,8 +42,8 @@ newtype Image = Image (Int, Int, V.Vector (Int, Int, Int))
 create_ppm :: Image -> BLB.Builder
 create_ppm (Image (w, h, ps)) =
   "P3\n" <>
-  "255\n" <>
   BLB.intDec w <> " " <> BLB.intDec h <> "\n" <>
+  "255\n" <>
   V.foldr (\ rgb acc -> acc <> rgb_tuple_to_str rgb <> "\n") "" ps
 
 write_ppm :: FilePath -> Image -> IO ()
@@ -62,6 +62,6 @@ test_create_ppm = BLB.toLazyByteString (
                                    RGB 55 56 57, RGB 66 67 68]))) ==
                   "P3\n2 3\n255\n11 12 13\n22 23 24\n33 34 35\n44 45 46\n55 56 57\n66 67 68\n"
 
--- test_write_ppm = write_ppm "test.ppm" (Image (16, 16, (map mkrgb [0..255])))
---   where
---     mkrgb x = RGB x x x
+test_write_ppm = write_ppm "test.ppm" (Image (16, 16, (V.map mkrgb (V.fromList [0..255]))))
+  where
+    mkrgb x = (x, x, x)

--- a/src/Image.hs
+++ b/src/Image.hs
@@ -1,49 +1,46 @@
-module Image where
+{-# LANGUAGE OverloadedStrings #-}
+module Image (RGB(..), Image(..), write_ppm) where
 
-import Control.DeepSeq
-import Control.Lens
-
-import Data.Tuple.Select
-
--- Join a list of strings using a separator.
-join :: String -> [String] -> String
-join sep [x] = x
-join sep (x:xs) = x ++ sep ++ join sep xs
-
--- Test for join
-test_join :: Bool
-test_join = join "t" ["12", "3", "", "xy"] == "12t3ttxy"
+import Data.List
+import Data.Monoid
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.ByteString.Builder as BLB
 
 data RGB = RGB {r :: !Int,
                 g :: !Int,
                 b :: !Int}
 
-instance NFData RGB where
-  rnf (RGB _ _ _) = ()
-
-rgb :: Iso' RGB (Int, Int, Int)
-rgb = iso (\(RGB r g b) -> (r, g, b)) ( \ (r, g, b) -> RGB r g b)
-
-instance Show RGB where show rgb = show $ rgb_to_str rgb
+instance Show RGB where
+  show = BL.unpack . BLB.toLazyByteString . rgb_to_str
 
 instance Num RGB where
   (+) (RGB r1 g1 b1) (RGB r2 g2 b2) = RGB (r1 + r2) (g1 + g2) (b1 + b2)
 
+intByteString :: Int -> BL.ByteString
+intByteString = BLB.toLazyByteString . BLB.intDec
+
 -- Convert an RGB to a String
-rgb_to_str :: RGB -> String
-rgb_to_str (RGB r g b) = join " " $ map show [r,g,b]
+rgb_to_str :: RGB -> BLB.Builder
+rgb_to_str (RGB r g b) = BLB.intDec r <> " " <> BLB.intDec g <> " " <> BLB.intDec b
 
 -- Test for rgb_to_str
 test_rgb_to_str :: Bool
-test_rgb_to_str = rgb_to_str (RGB 11 12 13) == "11 12 13"
+test_rgb_to_str = BLB.toLazyByteString (rgb_to_str (RGB 11 12 13)) == "11 12 13"
 
 newtype Image = Image (Int, Int, [RGB])
 
 -- Create a ppm file.
-create_ppm :: Image -> String
-create_ppm (Image (w, h, ps)) = join "\n" line_list ++ "\n"
+create_ppm :: Image -> BL.ByteString
+create_ppm (Image (w, h, ps)) = BL.unlines line_list
   where
-    line_list = ["P3", show w ++ " " ++ show h, "255"] ++ map rgb_to_str ps
+    rgbs = BLB.toLazyByteString
+      (mconcat (intersperse (BLB.char8 '\n') (map rgb_to_str ps)))
+
+    line_list :: [BL.ByteString]
+    line_list = ["P3", BL.unwords [intByteString w, intByteString h], "255", rgbs]
+
+write_ppm :: FilePath -> Image -> IO ()
+write_ppm file = BL.writeFile file . create_ppm
 
 -- -- Test for create_ppm
 test_create_ppm :: Bool
@@ -52,6 +49,6 @@ test_create_ppm = create_ppm (Image (2, 3, [RGB 11 12 13, RGB 22 23 24,
                                             RGB 55 56 57, RGB 66 67 68])) ==
                   "P3\n2 3\n255\n11 12 13\n22 23 24\n33 34 35\n44 45 46\n55 56 57\n66 67 68\n"
 
-test_write_ppm = writeFile "test.ppm" $ create_ppm (Image (16, 16, (map mkrgb [0..255])))
+test_write_ppm = write_ppm "test.ppm" (Image (16, 16, (map mkrgb [0..255])))
   where
     mkrgb x = RGB x x x

--- a/src/Intersect.hs
+++ b/src/Intersect.hs
@@ -4,9 +4,9 @@ import Image
 import Point
 import Vector
 
-data Surface = Sphere Point Scalar RGB deriving Show
+data Surface = Sphere !Point !Scalar !RGB deriving Show
 
-data Ray = Ray Point Vector deriving Show
+data Ray = Ray !Point !Vector deriving Show
 
 dscr :: Scalar -> Scalar -> Scalar -> Scalar
 dscr a b c = (b * b) - (4.0 * a * c)
@@ -28,5 +28,5 @@ surface_colour :: Surface -> RGB
 surface_colour (Sphere p r c) = c
 
 test_intersect = abs(a - 57.7350269189626) < 0.00001
-  where (a:as) = (ray_surface_intersect (Ray origin (Vector (1,1,1)))
-                                        (Sphere origin 100 (RGB (50,50,50))))
+  where (a:as) = (ray_surface_intersect (Ray origin (Vector 1 1 1))
+                                        (Sphere origin 100 (RGB 50 50 50)))

--- a/src/Intersect.hs
+++ b/src/Intersect.hs
@@ -1,4 +1,7 @@
-module Intersect where
+{-# LANGUAGE BangPatterns #-}
+
+module Intersect (Surface(..), Ray(..), Intersect(..),
+                  ray_surface_intersect, surface_colour) where
 
 import Image
 import Point
@@ -8,25 +11,38 @@ data Surface = Sphere !Point !Scalar !RGB deriving Show
 
 data Ray = Ray !Point !Vector deriving Show
 
+-- Represents different kind of intersections (no points, 1 point, 2 points).
+data Intersect =
+  Intr2 !Scalar !Scalar
+  | Intr1 !Scalar
+  | Intr0
+
 dscr :: Scalar -> Scalar -> Scalar -> Scalar
 dscr a b c = (b * b) - (4.0 * a * c)
 
-solve_quad :: Scalar -> Scalar -> Scalar -> [Scalar]
-solve_quad a b c = [((-b) + sqrtdscr) / (2.0 * a), ((-b) - sqrtdscr) / (2.0 * a)]
+solve_quad :: Scalar -> Scalar -> Scalar -> Intersect
+solve_quad a b c =
+  case (i1 > 0.00001, i2 > 0.000001) of
+    (True, True) -> Intr2 i1 i2
+    (True, False) -> Intr1 i1
+    (False, True) -> Intr1 i2
+    _ -> Intr0
   where
-    sqrtdscr = sqrt $ dscr a b c
+    !i1 = ((-b) + sqrtdscr) / (2.0 * a)
+    !i2 = ((-b) - sqrtdscr) / (2.0 * a)
+    !sqrtdscr = sqrt $ dscr a b c
 
-ray_surface_intersect :: Ray -> Surface -> [Scalar]
-ray_surface_intersect (Ray ro rd) (Sphere sx r col) = intersections
-  where intersections = filter (> 0.00001) $ solve_quad a b c
-        se = delta sx ro
-        a = vectorsum (rd * rd)
-        b = -2.0 * vectorsum (rd * se)
-        c = vectorsum (se * se) - (r * r)
+ray_surface_intersect :: Ray -> Surface -> Intersect
+ray_surface_intersect (Ray ro rd) (Sphere sx r col) = solve_quad a b c
+  where !se = delta sx ro
+        !a = dot2 rd
+        !b = -2.0 * dot rd se
+        !c = dot2 se - (r ** 2)
 
 surface_colour :: Surface -> RGB
 surface_colour (Sphere p r c) = c
 
 test_intersect = abs(a - 57.7350269189626) < 0.00001
-  where (a:as) = (ray_surface_intersect (Ray origin (Vector 1 1 1))
-                                        (Sphere origin 100 (RGB 50 50 50)))
+  where Intr2 a _ = ray_surface_intersect
+                    (Ray origin (Vector 1 1 1))
+                    (Sphere origin 100 (RGB 50 50 50))

--- a/src/Point.hs
+++ b/src/Point.hs
@@ -1,25 +1,21 @@
 module Point where
 
-import Data.Tuple.Select
+import Control.Lens
+
 import Vector
 
-newtype Point = Point (Scalar, Scalar, Scalar)
+newtype Point = Point Vector
+
 
 delta :: Point -> Point -> Vector
-delta (Point p) (Point q) = Vector(sel1 p - sel1 q,
-                                   sel2 p - sel2 q,
-                                   sel3 p - sel3 q)
+delta (Point p) (Point q) = p - q
 
 translate :: Point -> Vector -> Point
-translate (Point p) (Vector v) = Point (sel1 p + sel1 v,
-                                        sel2 p + sel2 v,
-                                        sel3 p + sel3 v)
+translate (Point p) v = Point (p + v)
 
 instance Eq Point where
-  (==) (Point p) (Point q) = all id [sel1 p == sel1 q,
-                                     sel2 p == sel2 q,
-                                     sel3 p == sel3 q]
+  (==) (Point p) (Point q) = p == q
 
 instance Show Point where show (Point p) = show p
 
-origin = Point (0,0,0)
+origin = Point (Vector 0 0 0)

--- a/src/Point.hs
+++ b/src/Point.hs
@@ -1,6 +1,4 @@
-module Point where
-
-import Control.Lens
+module Point (Point(..), delta, translate, origin) where
 
 import Vector
 

--- a/src/Raytrace.hs
+++ b/src/Raytrace.hs
@@ -1,15 +1,15 @@
-module Raytrace where
+{-# LANGUAGE BangPatterns #-}
+module Raytrace (Scene, Light(..), raytrace) where
 
-import Control.Lens
-import Control.Parallel.Strategies
 import Data.List
+import Data.Function
 
 import Image
 import Intersect
 import Point
 import Vector
 
-type Light = (Point, RGB)
+data Light = Light !Point !RGB
 type Scene = ([Surface], [Light])
 
 black = RGB 0 0 0
@@ -17,27 +17,30 @@ bgcolour = RGB 255 0 255
 
 -- get a ray from a camera location to a pixel
 ray_for_pixel :: Scalar -> Scalar -> Scalar -> Scalar -> Ray
-ray_for_pixel w h x y = r
-  where r = Ray origin direction
-        direction = normalize (delta p origin)
+ray_for_pixel !w !h !x !y = r
+  where !r = Ray origin direction
+        !direction = normalize (delta p origin)
         x' = (x / w) - 0.5
         y' = (y / h) - 0.5
         p = Point (Vector x'  y' 1.0)
 
+data Pair = Pair !Scalar !Scalar
+
 -- send rays over the scene and return an image.
-raytrace :: Scene -> Integer -> Integer -> Image
-raytrace scene width height = Image (fromInteger width, fromInteger height, ps')
-  where ps' = ps `using` parListChunk 128 rdeepseq
-        ps = [ get_colour_for_ray scene (ray_for_pixel w h x y) |
-               y <- map fromInteger [0..height - 1], x <- map fromInteger [0..width - 1] ]
-        w :: Scalar
-        w = fromInteger (width - 1)
-        h :: Scalar
-        h = fromInteger (height - 1)
+raytrace :: Scene -> Int -> Int -> Image
+raytrace scene width height = Image (width, height, ps)
+  where ps = [get_colour_for_ray scene (ray_for_pixel sw sh x y) | y <- [0..sh], x <- [0..sw]]
+        sw :: Scalar
+        sw = fromIntegral (width - 1)
+        sh :: Scalar
+        sh = fromIntegral (height - 1)
+
+data SurfInt = SurfInt Surface !Intersect
 
 -- get list of surfaces and Maybe distances to those surfaces which the ray intersects.
-get_ray_intersections :: Scene -> Ray -> [(Surface, [Scalar])]
-get_ray_intersections scene ray = [ (obj, ray_surface_intersect ray obj) | obj <- fst scene ]
+get_ray_intersections :: Scene -> Ray -> [SurfInt]
+get_ray_intersections scene !ray =
+  map (\obj -> SurfInt obj (ray_surface_intersect ray obj)) (fst scene)
 
 get_colour_for_ray :: Scene -> Ray -> RGB
 get_colour_for_ray scene ray = srdetectcolour' scene ray (srintersect scene ray)
@@ -53,16 +56,14 @@ srdetectcolour' scene (Ray ro rd) (Just (s, d)) = lightadded + (surface_colour s
         lightadded = foldl' (+) black (map effectivelight lightsvisible)
 
         colourTransform :: Point -> Int -> Int
-        colourTransform p = round
+        colourTransform !p = round
                             . (* 10000)
-                            . (/ (vectorsum ((delta intersectpoint p) ^ 2)))
+                            . (/ (dot2 (delta intersectpoint p)))
                             . fromIntegral
 
-        tupleTransform :: Point -> (Int, Int, Int) -> (Int, Int, Int)
-        tupleTransform p = over each (colourTransform p)
-
         effectivelight :: Light -> RGB
-        effectivelight (p, c) = over rgb (tupleTransform p) c
+        effectivelight (Light !p (RGB r g b)) =
+          RGB (colourTransform p r) (colourTransform p g) (colourTransform p b)
 
         intersectpoint = translate ro (mult d rd)
 srdetectcolour' scene r Nothing = bgcolour
@@ -70,29 +71,35 @@ srdetectcolour' scene r Nothing = bgcolour
 lightsvisiblefrom :: Point -> Scene -> [Light]
 lightsvisiblefrom x scene@(surfs, lights) = filter isvis lights
   where isvis :: Light -> Bool
-        isvis light = pastthelight (srintersect scene (Ray x (delta (fst light) x)))
+        isvis (Light p _) = pastthelight (srintersect scene (Ray x (delta p x)))
+
         pastthelight :: Maybe (Surface, Scalar) -> Bool
-        pastthelight Nothing = True
-        pastthelight (Just (s, d)) | d > 1 = True
-                                   | otherwise = False
+        pastthelight (Just (s, d)) | d <= 1 = False
+        pastthelight _ = True
 
 -- first surface intersection for ray.
 srintersect :: Scene -> Ray -> Maybe (Surface, Scalar)
-srintersect scene ray = min_intersection $ flatten_intersections $ get_ray_intersections scene ray
+srintersect scene ray = find_min_intersection $ get_ray_intersections scene ray
 
-flatten_intersections :: [(Surface, [Scalar])] -> [(Surface, Scalar)]
-flatten_intersections ((surf, []):extra) = flatten_intersections extra
-flatten_intersections ((surf, xs):extra) = ((flatten_intersections' surf xs) ++ (flatten_intersections extra))
-flatten_intersections [] = []
-
-flatten_intersections' :: Surface -> [Scalar] -> [(Surface, Scalar)]
-flatten_intersections' surf (x:xs) = (surf, x):(flatten_intersections' surf xs)
-flatten_intersections' surf[] = []
-
-min_intersection :: [(Surface, Scalar)] -> Maybe (Surface, Scalar)
-min_intersection ((sa, a):(sb, b):extra) | a < b = min_intersection ((sa, a):extra)
-                                         | otherwise = min_intersection ((sb, b):extra)
-min_intersection [] = Nothing
-min_intersection [(sa, a)] = Just (sa, a)
+find_min_intersection :: [SurfInt] -> Maybe (Surface, Scalar)
+find_min_intersection xs = foldl' go Nothing xs
+  where
+    go :: Maybe (Surface, Scalar) -> SurfInt -> Maybe (Surface, Scalar)
+    go acc@(Just (accS, !accI)) (SurfInt s !inter) =
+      case inter of
+        Intr0 -> acc
+        Intr1 a -> if a < accI
+                   then Just (s, a)
+                   else acc
+        Intr2 a b ->
+          let c = min a b
+          in if c < accI
+             then Just (s, c)
+             else acc
+    go Nothing (SurfInt !s !inter) =
+      case inter of
+        Intr0 -> Nothing
+        Intr1 a ->  Just (s, a)
+        Intr2 a b -> Just (s, min a b)
 
 

--- a/src/Raytrace.hs
+++ b/src/Raytrace.hs
@@ -24,8 +24,6 @@ ray_for_pixel !w !h !x !y = r
         y' = (y / h) - 0.5
         p = Point (Vector x'  y' 1.0)
 
-data Pair = Pair !Scalar !Scalar
-
 -- send rays over the scene and return an image.
 raytrace :: Scene -> Int -> Int -> Image
 raytrace scene width height = Image (width, height, ps)

--- a/src/Vector.hs
+++ b/src/Vector.hs
@@ -1,39 +1,46 @@
 module Vector where
 
-import Data.Tuple.Select
+import Control.Lens
 
 type Scalar = Double
 
-newtype Vector = Vector (Scalar, Scalar, Scalar)
+data Vector = Vector {
+  x :: !Scalar,
+  y :: !Scalar,
+  z :: !Scalar
+  }
+
+
+vector :: Iso' Vector (Scalar, Scalar, Scalar)
+vector = iso ( \(Vector x y z) -> (x, y, z))
+  (\ (x, y, z) -> Vector x y z)
 
 instance Num Vector where
-  (+) (Vector xs) (Vector ys) = Vector (sel1 xs + sel1 ys,
-                                        sel2 xs + sel2 ys,
-                                        sel3 xs + sel3 ys)
-  (-) (Vector xs) (Vector ys) = Vector (sel1 xs - sel1 ys,
-                                        sel2 xs - sel2 ys,
-                                        sel3 xs - sel3 ys)
-  (*) (Vector xs) (Vector ys) = Vector (sel1 xs * sel1 ys,
-                                        sel2 xs * sel2 ys,
-                                        sel3 xs * sel3 ys)
-  negate (Vector xs) = Vector (0 - sel1 xs, 0 - sel2 xs, 0 - sel3 xs)
+  (+) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 + x2)
+                                        (y1 + y2)
+                                        (z1 + z2)
+  (-) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 - x2)
+                                        (y1 - y2)
+                                        (z1 - z2)
+  (*) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 * x2)
+                                        (y1 * y2)
+                                        (z1 * z2)
+  negate (Vector x y z) = Vector (0 - x) (0 - y) (0 - z)
   fromInteger x = error "failed to convert integer to vector"
 
 instance Eq Vector where
-  (==) (Vector xs) (Vector ys) = all id [sel1 xs == sel1 ys,
-                                         sel2 xs == sel2 ys,
-                                         sel3 xs == sel3 ys]
+  (==) (Vector x1 y1 z1) (Vector x2 y2 z2) = x1 == x2 && y1 == y2 && z1 == z2
 
-instance Show Vector where show (Vector xs) = show xs
+instance Show Vector where show (Vector x y z) = show (x, y, z)
 
 mult :: Scalar -> Vector -> Vector
-mult s (Vector xs) = Vector (sel1 xs * s, sel2 xs * s, sel3 xs * s)
+mult s (Vector x y z) = Vector (x * s) (y * s) (z * s)
 
 vectorsum :: Vector -> Scalar
-vectorsum (Vector xs) = sel1 xs + sel2 xs + sel3 xs
+vectorsum (Vector x y z) = x + y + z
 
 normalize :: Vector -> Vector
-normalize v@(Vector vs) = Vector (sel1 vs / mag, sel2 vs / mag, sel3 vs / mag)
+normalize v@(Vector x y z) = Vector (x / mag) (y / mag) (z / mag)
   where
     mag = sqrt $ dot v v
 

--- a/src/Vector.hs
+++ b/src/Vector.hs
@@ -1,6 +1,5 @@
-module Vector where
-
-import Control.Lens
+{-# LANGUAGE BangPatterns #-}
+module Vector (dot, dot2, normalize, mult, Scalar, Vector(..)) where
 
 type Scalar = Double
 
@@ -10,21 +9,10 @@ data Vector = Vector {
   z :: !Scalar
   }
 
-
-vector :: Iso' Vector (Scalar, Scalar, Scalar)
-vector = iso ( \(Vector x y z) -> (x, y, z))
-  (\ (x, y, z) -> Vector x y z)
-
 instance Num Vector where
-  (+) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 + x2)
-                                        (y1 + y2)
-                                        (z1 + z2)
-  (-) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 - x2)
-                                        (y1 - y2)
-                                        (z1 - z2)
-  (*) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 * x2)
-                                        (y1 * y2)
-                                        (z1 * z2)
+  (+) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 + x2) (y1 + y2) (z1 + z2)
+  (-) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 - x2) (y1 - y2) (z1 - z2)
+  (*) (Vector x1 y1 z1) (Vector x2 y2 z2) = Vector (x1 * x2) (y1 * y2) (z1 * z2)
   negate (Vector x y z) = Vector (0 - x) (0 - y) (0 - z)
   fromInteger x = error "failed to convert integer to vector"
 
@@ -40,9 +28,12 @@ vectorsum :: Vector -> Scalar
 vectorsum (Vector x y z) = x + y + z
 
 normalize :: Vector -> Vector
-normalize v@(Vector x y z) = Vector (x / mag) (y / mag) (z / mag)
+normalize v = mult (1/mag) v
   where
-    mag = sqrt $ dot v v
+    !mag = sqrt $ dot2 v
 
 dot :: Vector -> Vector -> Scalar
 dot xs ys = vectorsum (xs * ys)
+
+dot2 :: Vector -> Scalar
+dot2 (Vector x y z) = x ^ 2 + y ^ 2 + z ^ 2


### PR DESCRIPTION
I guess this upended a lot of code, but basically there are a few main themes:
- define unique datatypes, and add strictness annotations there to help unboxing (memory usage/gc)
- fuse some loops that don't "really" need a loop, i.e. iterating over a list of intersection options -> just use an intersection type and search for the minimum with a fold
- use Repa to generate the array
- generate the output string from a ByteString builder
- a few compile opts changes (mostly fiddling, maybe should add "-N -qg" as well?)
